### PR TITLE
[OWL-254] set null response message if no host found

### DIFF
--- a/http/zabbix.go
+++ b/http/zabbix.go
@@ -722,7 +722,7 @@ func hostgroupDelete(nodes map[string]interface{}) {
  * @return:          void
  * @author:          Don Hsieh
  * @since:           12/29/2015
- * @last modified:   01/01/2016
+ * @last modified:   01/07/2016
  * @called by:       func apiParser(rw http.ResponseWriter, req *http.Request)
  */
 func hostgroupGet(nodes map[string]interface{}) {
@@ -770,7 +770,7 @@ func hostgroupGet(nodes map[string]interface{}) {
 			if err == orm.ErrMultiRows {
 				setError("returned multiple rows", result)
 			} else if err == orm.ErrNoRows {
-				setError("host group not found", result)
+				log.Println("host group not found")
 			} else if grp.Id > 0 {
 				groupId = strconv.Itoa(grp.Id)
 			}

--- a/http/zabbix.go
+++ b/http/zabbix.go
@@ -504,7 +504,7 @@ func hostDelete(nodes map[string]interface{}) {
  * @return:          void
  * @author:          Don Hsieh
  * @since:           12/29/2015
- * @last modified:   01/06/2016
+ * @last modified:   01/07/2016
  * @called by:       func apiParser(rw http.ResponseWriter, req *http.Request)
  */
 func hostGet(nodes map[string]interface{}) {
@@ -561,7 +561,7 @@ func hostGet(nodes map[string]interface{}) {
 			if err == orm.ErrMultiRows {
 				setError("returned multiple rows", result)
 			} else if err == orm.ErrNoRows {
-				setError("host not found", result)
+				log.Println("host not found")
 			} else if host.Id > 0 {
 				ip = host.Ip
 				var grp_id int


### PR DESCRIPTION
```
modified:   http/zabbix.go
```
### Example request:

```
{
    "jsonrpc": "2.0",
    "method": "hostgroup.get",
    "params": {
        "output": "extend",
        "filter": {
            "name": [
                "group1",
                "group2"
            ]
        }
    },
}
```
### Response (before PR):

```
{
  "error": [
    "host group not found"
  ],
  "jsonrpc": "2.0",
  "time": "2016-01-08 10:38:31"
}
```

The response is null if one of the host groups doesn't exist. We should return the existed host groups and let those host groups not existed be null.
### Response (after PR):

```
{
  "jsonrpc": "2.0",
  "result": [
    {
      "groupid": "15",
      "groupname": "group1"
    },
    {
      "groupid": "", // group2 is not found, let this field empty
      "groupname": "group2"
    }
  ],
  "time": "2016-01-08 10:32:52"
}
```
