### PR TITLE
[OWL-254] enable host.get to return multiple groupids

### DIFF
--- a/http/zabbix.go
+++ b/http/zabbix.go
@@ -497,6 +497,32 @@ func hostDelete(nodes map[string]interface{}) {
 }
 
 /**
+ * @function name:   func getGroups(hostId string) []interface{}
+ * @description:     This function gets hostgroups which contain the host ID.
+ * @related issues:  OWL-254
+ * @param:           hostId string
+ * @return:          groups []interface{}
+ * @author:          Don Hsieh
+ * @since:           01/12/2016
+ * @last modified:   01/12/2016
+ * @called by:       func hostGet(nodes map[string]interface{})
+ */
+func getGroups(hostId string) []interface{} {
+	groups := []interface{}{}
+	o := orm.NewOrm()
+	var grp_ids []int
+	o.Raw("SELECT grp_id FROM falcon_portal.grp_host WHERE host_id=?", hostId).QueryRows(&grp_ids)
+	for _, grp_id := range grp_ids {
+		groupId := strconv.Itoa(grp_id)
+		group := map[string]string {
+			"groupid": groupId,
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+/**
  * @function name:   func hostGet(nodes map[string]interface{})
  * @description:     This function gets existed host data.
  * @related issues:  OWL-262, OWL-257, OWL-254


### PR DESCRIPTION
```
modified:   http/zabbix.go
```
### Request:

```
{
    "jsonrpc": "2.0",
    "method": "host.get",
    "params": {
        "output": "extend",
        "filter": {
            "host": [
                "host_name"
            ]
        }
    }
}
```
### Response: (before PR)

```
{
  "jsonrpc": "2.0",
  "result": [
    {
      "groupid": "2",
      "hostid": "1",
      "hostname": "host_name",
      "ip": "78.88.89.99"
    }
  ],
  "time": "2016-01-12 15:07:55"
}
```
### Response: (after PR)

```
{
  "jsonrpc": "2.0",
  "result": [
    {
      "groups": [
        {
          "groupid": "2"
        },
        {
          "groupid": "3"
        }
      ],
      "hostid": "1",
      "hostname": "host_name",
      "ip": "78.88.89.99"
    }
  ],
  "time": "2016-01-12 15:07:55"
}
```
