### PR TITLE
[OWL-275] Support features of nqm

### DIFF
--- a/http/graph_http.go
+++ b/http/graph_http.go
@@ -40,49 +40,198 @@ func configGraphRoutes() {
 		}
 
 		data := []*cmodel.GraphQueryResponse{}
+		isPacketLossRate := false
 		for _, ec := range body.EndpointCounters {
 			if strings.Contains(ec.Counter,"packet-loss-rate") {
-				requestPacketsSent := cmodel.GraphQueryParam{
-					Start:     int64(body.Start),
-					End:       int64(body.End),
-					ConsolFun: body.CF,
-					Endpoint:  ec.Endpoint,
-					Counter:   strings.Replace(ec.Counter, "packet-loss-rate", "packets-sent", 1),
+				isPacketLossRate = true
+				break
+			}
+		}
+		isAverage := false
+		for _, ec := range body.EndpointCounters {
+			if strings.Contains(ec.Counter,"average") {
+				isAverage = true
+				break
+			}
+		}
+		if isPacketLossRate {
+			//var result *cmodel.GraphQueryResponse
+			/**result = cmodel.GraphQueryResponse{
+				Endpoint:    "all-endpoints",
+				Counter:     "packet-loss-rate", 
+				DsType:      "GAUGE", 
+				Step:        60, 
+				Values:      []*cmodel.RRDData{},
+			}*/
+			
+			/**
+			 * 下面這段，只是想先製造一個跟 packets-sent 的 response 一樣的 struct
+			 */
+			var result *cmodel.GraphQueryResponse
+			var packetSentCount []cmodel.JsonFloat
+			for _, ec := range body.EndpointCounters {
+				if strings.Contains(ec.Counter,"packets-sent") {
+					request := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   ec.Counter,
+					}
+					result, err = graph.QueryOne(request)
+					for i := range result.Values {
+						result.Values[i].Value = cmodel.JsonFloat(0.0)
+						packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
+					}
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					break
 				}
-				resultPacketsSent, err := graph.QueryOne(requestPacketsSent)
-				if err != nil {
-					log.Printf("graph.queryOne fail, %v", err)
-				}
-				if resultPacketsSent == nil {
-					continue
+			}
+			
+			for _, ec := range body.EndpointCounters {
+
+				if strings.Contains(ec.Counter,"packets-sent") {
+					
+					requestPacketsSent := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   ec.Counter, //strings.Replace(ec.Counter, "packet-loss-rate", "packets-sent", 1),
+					}
+					resultPacketsSent, err := graph.QueryOne(requestPacketsSent)
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					if resultPacketsSent == nil {
+						continue
+					}
+					data = append(data, resultPacketsSent)
+
+					requestPacketReceived := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   strings.Replace(ec.Counter, "packets-sent", "packets-received", 1),
+					}
+					resultPacketReceived, err := graph.QueryOne(requestPacketReceived)
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					if resultPacketReceived == nil {
+						continue
+					}
+					data = append(data, resultPacketReceived)
+					for i := range resultPacketsSent.Values {
+						/**
+						 * 下面這行會讓 resultValues 的 Timestamp 取到最後一個 endpoint-counter pair 的 Timestamp
+						 */
+						// 上面有了 result 後這邊就不需要了 //result.Values[i].Timestamp = resultPacketsSent.Values[i].Timestamp
+
+						packetLossCount := (resultPacketsSent.Values[i].Value		-
+											resultPacketReceived.Values[i].Value)
+						result.Values[i].Value += packetLossCount
+						packetSentCount[i] += resultPacketsSent.Values[i].Value
+						log.Printf("sentCnt = %f, rcvCnt = %f, totalLossCnt = %f, totalSentCnt = %f",float64(resultPacketsSent.Values[i].Value), float64(resultPacketReceived.Values[i].Value), float64(result.Values[i].Value), float64(packetSentCount[i]))
+					}
 				}
 
-				requestPacketReceived := cmodel.GraphQueryParam{
-					Start:     int64(body.Start),
-					End:       int64(body.End),
-					ConsolFun: body.CF,
-					Endpoint:  ec.Endpoint,
-					Counter:   strings.Replace(ec.Counter, "packet-loss-rate", "packets-received", 1),
+			}
+			
+			result.Endpoint = "all-endpoints"
+			result.Counter = "packet-loss-rate"
+			for i := range result.Values {
+				//log.Printf("diff = %f, sentCnt = %f",float64(result.Values[i].Value), float64(packetSentCount))
+				result.Values[i].Value = result.Values[i].Value/packetSentCount[i]
+			}
+			result.Values = result.Values
+			data = append(data, result)
+							
+		} else if isAverage {
+			/**
+			 * 下面這段，只是想先製造一個跟 transmission-time 的 response 一樣的 struct
+			 */
+			var result *cmodel.GraphQueryResponse
+			var packetSentCount []cmodel.JsonFloat
+			for _, ec := range body.EndpointCounters {
+				if strings.Contains(ec.Counter,"transmission-time") {
+					request := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   ec.Counter,
+					}
+					result, err = graph.QueryOne(request)
+					for i := range result.Values {
+						result.Values[i].Value = cmodel.JsonFloat(0.0)
+						packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
+					}
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					break
 				}
-				resultPacketReceived, err := graph.QueryOne(requestPacketReceived)
-				if err != nil {
-					log.Printf("graph.queryOne fail, %v", err)
-				}
-				if resultPacketReceived == nil {
-					continue
+			}
+			for _, ec := range body.EndpointCounters {
+
+				if strings.Contains(ec.Counter,"transmission-time") {
+					
+					requestTransmissionTime := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   ec.Counter,
+					}
+					resultTransmissionTime, err := graph.QueryOne(requestTransmissionTime)
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					if resultTransmissionTime == nil {
+						continue
+					}
+					data = append(data, resultTransmissionTime)
+
+					requestPacketsSent := cmodel.GraphQueryParam{
+						Start:     int64(body.Start),
+						End:       int64(body.End),
+						ConsolFun: body.CF,
+						Endpoint:  ec.Endpoint,
+						Counter:   strings.Replace(ec.Counter, "transmission-time", "packets-sent", 1),
+					}
+					resultPacketsSent, err := graph.QueryOne(requestPacketsSent)
+					if err != nil {
+						log.Printf("graph.queryOne fail, %v", err)
+					}
+					if resultPacketsSent == nil {
+						continue
+					}
+					data = append(data, resultPacketsSent)
+
+					for i := range resultTransmissionTime.Values {
+						result.Values[i].Value += resultTransmissionTime.Values[i].Value * resultPacketsSent.Values[i].Value
+						packetSentCount[i] += resultPacketsSent.Values[i].Value
+						//log.Printf("sentCnt = %f, rcvCnt = %f, totalLossCnt = %f, totalSentCnt = %f",float64(resultPacketsSent.Values[i].Value), float64(resultPacketReceived.Values[i].Value), float64(result.Values[i].Value), float64(packetSentCount[i]))
+					}
 				}
 
-				result := resultPacketsSent
-				result.Counter = strings.Replace(result.Counter, "packets-sent", "packet-loss-rate", 1)
-
-				for i := range result.Values {
-					packetLossRate :=  (resultPacketsSent.Values[i].Value		-
-									resultPacketReceived.Values[i].Value)	/
-									resultPacketsSent.Values[i].Value
-					result.Values[i].Value = packetLossRate
-				}
-				data = append(data, result)
-			} else {
+			}
+			
+			result.Endpoint = "all-endpoints"
+			result.Counter = "average"
+			for i := range result.Values {
+				//log.Printf("diff = %f, sentCnt = %f",float64(result.Values[i].Value), float64(packetSentCount))
+				result.Values[i].Value = result.Values[i].Value/packetSentCount[i]
+			}
+			result.Values = result.Values
+			data = append(data, result)
+			
+		} else {
+			for _, ec := range body.EndpointCounters {
 				request := cmodel.GraphQueryParam{
 					Start:     int64(body.Start),
 					End:       int64(body.End),

--- a/http/graph_http.go
+++ b/http/graph_http.go
@@ -41,6 +41,80 @@ func graphQueryOne(ec cmodel.GraphInfoParam, body GraphHistoryParam, endpoint st
 	return result
 }
 
+func makeOneFakeResult(body GraphHistoryParam) *cmodel.GraphQueryResponse {
+	for _, ec := range body.EndpointCounters {
+		if !strings.Contains(ec.Counter,"packet-loss-rate") && !strings.Contains(ec.Counter,"average") {
+			fakeResult := graphQueryOne(ec, body,"" , "")
+			for i := range fakeResult.Values {
+				fakeResult.Values[i].Value = cmodel.JsonFloat(0.0)
+			}
+			return fakeResult
+		}
+	}
+	return nil
+}
+
+func detectCounter(counter string, body GraphHistoryParam) bool {
+	for _, ec := range body.EndpointCounters {		
+		if strings.Contains(ec.Counter, counter) {		
+			return true		
+		}		
+	}
+	return false
+}
+
+func nqmData(body GraphHistoryParam, nqmDataCounter string, rawDataCounter string) []*cmodel.GraphQueryResponse {
+
+	result := makeOneFakeResult(body)
+	if result == nil {
+		return nil
+	}
+	data := []*cmodel.GraphQueryResponse{}
+	packetSentCount := make([]cmodel.JsonFloat, len(result.Values))
+	for i := range result.Values {
+		packetSentCount[i] = cmodel.JsonFloat(0.0)
+	}
+	for _, ec := range body.EndpointCounters {
+		if !strings.Contains(ec.Counter, rawDataCounter) {
+			continue
+		}
+
+		resultRaw := graphQueryOne(ec, body, "", "")
+		if resultRaw == nil {
+			continue
+		}
+		data = append(data, resultRaw)
+
+		if rawDataCounter == "packets-sent" {
+			counter := strings.Replace(ec.Counter, "packets-sent", "packets-received", 1)
+			if resultAdditional := graphQueryOne(ec, body, "", counter); resultAdditional != nil {
+				data = append(data, resultAdditional)
+				for i := range resultRaw.Values {
+					packetLossCount := (resultRaw.Values[i].Value - resultAdditional.Values[i].Value)
+					result.Values[i].Value += packetLossCount
+					packetSentCount[i] += resultRaw.Values[i].Value
+				}
+			}
+		} else if rawDataCounter == "transmission-time" {
+			counter := strings.Replace(ec.Counter, "transmission-time", "packets-sent", 1)
+			if resultAdditional := graphQueryOne(ec, body, "", counter); resultAdditional != nil {
+				data = append(data, resultAdditional)
+				for i := range resultAdditional.Values {
+					result.Values[i].Value += resultAdditional.Values[i].Value * resultRaw.Values[i].Value
+					packetSentCount[i] += resultAdditional.Values[i].Value
+				}
+			}
+		}
+	}
+	for i := range result.Values {
+		result.Values[i].Value = result.Values[i].Value / packetSentCount[i]
+	}
+	result.Endpoint = "all-endpoints"
+	result.Counter = nqmDataCounter
+	data = append(data, result)
+	return data
+}
+
 func configGraphRoutes() {
 
 	// method:post
@@ -62,66 +136,23 @@ func configGraphRoutes() {
 		}
 
 		data := []*cmodel.GraphQueryResponse{}
-		var result *cmodel.GraphQueryResponse
-		for _, ec := range body.EndpointCounters {
-			if strings.Contains(ec.Counter, "packets-sent") || strings.Contains(ec.Counter, "transmission-time") {
-				// NQM Case
-				var packetSentCount []cmodel.JsonFloat
-				// clone a response
-				result = graphQueryOne(ec, body, "", "")
-				for i := range result.Values {
-					result.Values[i].Value = cmodel.JsonFloat(0.0)
-					packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
-				}
-				if result == nil {
-					continue
-				}
 
-				resultSent := graphQueryOne(ec, body, "", "")
-				if resultSent == nil {
-					continue
-				}
-				data = append(data, resultSent)
-
-				if strings.Contains(ec.Counter, "packets-sent") {
-					counter := strings.Replace(ec.Counter, "packets-sent", "packets-received", 1)
-					if resultReceived := graphQueryOne(ec, body, "", counter); resultReceived != nil {
-						data = append(data, result)
-						for i := range resultSent.Values {
-							packetLossCount := (resultSent.Values[i].Value - resultReceived.Values[i].Value)
-							result.Values[i].Value += packetLossCount
-							packetSentCount[i] += resultSent.Values[i].Value
-						}
-					}
-				} else if strings.Contains(ec.Counter, "transmission-time") {
-					counter := strings.Replace(ec.Counter, "transmission-time", "packets-sent", 1)
-					if resultTransmissionTime := graphQueryOne(ec, body, "", counter); resultTransmissionTime != nil {
-						data = append(data, resultSent)
-						for i := range resultTransmissionTime.Values {
-							result.Values[i].Value += resultTransmissionTime.Values[i].Value * resultSent.Values[i].Value
-							packetSentCount[i] += resultSent.Values[i].Value
-						}
-					}
-				}
-
-				if strings.Contains(ec.Counter, "packets-sent") {
-					result.Endpoint = "all-endpoints"
-					result.Counter = "packet-loss-rate"
-				} else if strings.Contains(ec.Counter, "transmission-time") {
-					result.Endpoint = "all-endpoints"
-					result.Counter = "average"
-				}
-				for i := range result.Values {
-					result.Values[i].Value = result.Values[i].Value / packetSentCount[i]
-				}
-				result.Values = result.Values
-				data = append(data, result)
-
-			} else {
+		isPacketLossRate := detectCounter("packet-loss-rate", body)
+		isAverage := detectCounter("average", body)
+		
+		if isPacketLossRate || isAverage {
+			// NQM Case
+			if isPacketLossRate {
+				data = append(data, nqmData(body, "packet-loss-rate", "packets-sent")... )
+			} else if isAverage {
+				data = append(data, nqmData(body, "average", "transmission-time")... )
+			}
+		} else {
+			for _, ec := range body.EndpointCounters {
 				regx, _ := regexp.Compile("(\\.\\$\\s*|\\s*)$")
 				endpoint := regx.ReplaceAllString(ec.Endpoint, "")
 				counter := regx.ReplaceAllString(ec.Counter, "")
-				result = graphQueryOne(ec, body, endpoint, counter)
+				result := graphQueryOne(ec, body, endpoint, counter)
 				if result == nil {
 					continue
 				}

--- a/http/graph_http.go
+++ b/http/graph_http.go
@@ -20,6 +20,27 @@ type GraphHistoryParam struct {
 	EndpointCounters []cmodel.GraphInfoParam `json:"endpoint_counters"`
 }
 
+func graphQueryOne(body GraphHistoryParam, ec cmodel.GraphInfoParam, endpoint string, counter string) {
+	if endpoint == nil {
+		endpoint = ec.Endpoint
+	}
+	if counter == nil {
+		counter = ec.Counter
+	}
+	request := cmodel.GraphQueryParam{
+		Start:     int64(body.Start),
+		End:       int64(body.End),
+		ConsolFun: body.CF,
+		Endpoint:  endpoint,
+		Counter:   counter,
+	}
+	result, err := graph.QueryOne(request)
+	if err != nil {
+		log.Printf("graph.queryOne fail, %v, (endpoint, counter) = (%s, %s)", err, endpoint, counter)
+	}
+	return result
+}
+
 func configGraphRoutes() {
 
 	// method:post
@@ -39,210 +60,75 @@ func configGraphRoutes() {
 			StdRender(w, "", errors.New("empty_payload"))
 			return
 		}
+
 		data := []*cmodel.GraphQueryResponse{}
 		var result *cmodel.GraphQueryResponse
-		isPacketLossRate := false
 		for _, ec := range body.EndpointCounters {
-			if strings.Contains(ec.Counter, "packet-loss-rate") {
-				isPacketLossRate = true
-				break
-			}
-		}
-		isAverage := false
-		for _, ec := range body.EndpointCounters {
-			if strings.Contains(ec.Counter, "average") {
-				isAverage = true
-				break
-			}
-		}
-		if isPacketLossRate {
-			/**
-			 * 下面這段，只是想先做一個跟 packets-sent 的 response 一樣的 struct
-			 */
-			var packetSentCount []cmodel.JsonFloat
-			for _, ec := range body.EndpointCounters {
+			if strings.Contains(ec.Counter, "packets-sent") || strings.Contains(ec.Counter, "transmission-time") {
+				// NQM Case
+				var packetSentCount []cmodel.JsonFloat
+				// clone a response
+				result = graphQueryOne(ec, body, nil, nil)
+				for i := range result.Values {
+					result.Values[i].Value = cmodel.JsonFloat(0.0)
+					packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
+				}
+				if result == nil {
+					continue
+				}
+
+				resultSent = graphQueryOne(ec, body, nil, nil)
+				if resultSent == nil {
+					continue
+				}
+				data = append(data, resultSent)
+
 				if strings.Contains(ec.Counter, "packets-sent") {
-					request := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   ec.Counter,
+					counter = strings.Replace(ec.Counter, "packets-sent", "packets-received", 1)
+					if resultReceived = graphQueryOne(ec, body, nil, counter); resultReceived {
+						data = append(data, result)
+						for i := range resultSent.Values {
+							packetLossCount := (resultSent.Values[i].Value - resultReceived.Values[i].Value)
+							result.Values[i].Value += packetLossCount
+							packetSentCount[i] += resultSent.Values[i].Value
+						}
 					}
-					result, err = graph.QueryOne(request)
-					for i := range result.Values {
-						result.Values[i].Value = cmodel.JsonFloat(0.0)
-						packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
+				} else if strings.Contains(ec.Counter, "transmission-time") {
+					counter = strings.Replace(ec.Counter, "transmission-time", "packets-sent", 1)
+					if resultTransmissionTime = graphQueryOne(ec, body, nil, counter); resultTransmissionTime {
+						data = append(data, resultPacketsSent)
+						for i := range resultTransmissionTime.Values {
+							result.Values[i].Value += resultTransmissionTime.Values[i].Value * resultPacketsSent.Values[i].Value
+							packetSentCount[i] += resultPacketsSent.Values[i].Value
+						}
 					}
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					break
 				}
-			}
 
-			for _, ec := range body.EndpointCounters {
-				/**
-				 * 此版本中，在 dashboard 查詢 packet-loss-rate 的時候，
-				 * dashboard 會以 packets-sent 這個 metric 來呈現搜尋到的結果。
-				 */
 				if strings.Contains(ec.Counter, "packets-sent") {
-					/**
-					 * 此版本中，packet-loss-rate 的 data，
-					 * 必須跟 packets-sent & packets-eceived 一起看。
-					 */
-					requestPacketsSent := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   ec.Counter,
-					}
-					resultPacketsSent, err := graph.QueryOne(requestPacketsSent)
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					if resultPacketsSent == nil {
-						continue
-					}
-					data = append(data, resultPacketsSent)
-
-					requestPacketReceived := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   strings.Replace(ec.Counter, "packets-sent", "packets-received", 1),
-					}
-					resultPacketReceived, err := graph.QueryOne(requestPacketReceived)
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					if resultPacketReceived == nil {
-						continue
-					}
-					data = append(data, resultPacketReceived)
-					for i := range resultPacketsSent.Values {
-						packetLossCount := (resultPacketsSent.Values[i].Value -
-							resultPacketReceived.Values[i].Value)
-						result.Values[i].Value += packetLossCount
-						packetSentCount[i] += resultPacketsSent.Values[i].Value
-					}
+					result.Endpoint = "all-endpoints"
+					result.Counter = "packet-loss-rate"
+				} else if strings.Contains(ec.Counter, "transmission-time") {
+					result.Endpoint = "all-endpoints"
+					result.Counter = "average"
 				}
-
-			}
-
-			result.Endpoint = "all-endpoints"
-			result.Counter = "packet-loss-rate"
-			for i := range result.Values {
-				result.Values[i].Value = result.Values[i].Value / packetSentCount[i]
-			}
-			result.Values = result.Values
-			data = append(data, result)
-
-		} else if isAverage {
-			/**
-			 * 下面這段，只是想先製造一個跟 transmission-time 的 response 一樣的 struct
-			 */
-			var packetSentCount []cmodel.JsonFloat
-			for _, ec := range body.EndpointCounters {
-				if strings.Contains(ec.Counter, "transmission-time") {
-					request := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   ec.Counter,
-					}
-					result, err = graph.QueryOne(request)
-					for i := range result.Values {
-						result.Values[i].Value = cmodel.JsonFloat(0.0)
-						packetSentCount = append(packetSentCount, cmodel.JsonFloat(0.0))
-					}
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					break
+				for i := range result.Values {
+					result.Values[i].Value = result.Values[i].Value / packetSentCount[i]
 				}
-			}
-			for _, ec := range body.EndpointCounters {
-				/**
-				 * 此版本中，在 dashboard 查詢 average 的時候，
-				 * dashboard 會以 transmission-time 這個 metric 來呈現搜尋到的結果。
-				 */
-				if strings.Contains(ec.Counter, "transmission-time") {
-					/**
-					 * 此版本中，average 的 data，
-					 * 必須跟 transmission-time & packets-sent 一起看。
-					 */
-					requestTransmissionTime := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   ec.Counter,
-					}
-					resultTransmissionTime, err := graph.QueryOne(requestTransmissionTime)
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					if resultTransmissionTime == nil {
-						continue
-					}
-					data = append(data, resultTransmissionTime)
+				result.Values = result.Values
+				data = append(data, result)
 
-					requestPacketsSent := cmodel.GraphQueryParam{
-						Start:     int64(body.Start),
-						End:       int64(body.End),
-						ConsolFun: body.CF,
-						Endpoint:  ec.Endpoint,
-						Counter:   strings.Replace(ec.Counter, "transmission-time", "packets-sent", 1),
-					}
-					resultPacketsSent, err := graph.QueryOne(requestPacketsSent)
-					if err != nil {
-						log.Printf("graph.queryOne fail, %v", err)
-					}
-					if resultPacketsSent == nil {
-						continue
-					}
-					data = append(data, resultPacketsSent)
-					for i := range resultTransmissionTime.Values {
-						result.Values[i].Value += resultTransmissionTime.Values[i].Value * resultPacketsSent.Values[i].Value
-						packetSentCount[i] += resultPacketsSent.Values[i].Value
-					}
-				}
-
-			}
-
-			result.Endpoint = "all-endpoints"
-			result.Counter = "average"
-			for i := range result.Values {
-				result.Values[i].Value = result.Values[i].Value / packetSentCount[i]
-			}
-			result.Values = result.Values
-			data = append(data, result)
-
-		} else {
-			regx, _ := regexp.Compile("(\\.\\$\\s*|\\s*)$")
-			for _, ec := range body.EndpointCounters {
-				request := cmodel.GraphQueryParam{
-					Start:     int64(body.Start),
-					End:       int64(body.End),
-					ConsolFun: body.CF,
-					Endpoint:  regx.ReplaceAllString(ec.Endpoint, ""),
-					Counter:   regx.ReplaceAllString(ec.Counter, ""),
-				}
-				result, err := graph.QueryOne(request)
-				if err != nil {
-					log.Printf("graph.queryOne fail, %v", err)
-				}
+			} else {
+				regx, _ := regexp.Compile("(\\.\\$\\s*|\\s*)$")
+				endpoint = regx.ReplaceAllString(ec.Endpoint, "")
+				counter = regx.ReplaceAllString(ec.Counter, "")
+				result = graphQueryOne(ec, body, endpoint, counter)
 				if result == nil {
 					continue
 				}
 				data = append(data, result)
 			}
-			log.Println("got length of data: ", len(data))
 		}
+		log.Println("got length of data: ", len(data))
 
 		// statistics
 		proc.HistoryResponseCounterCnt.IncrBy(int64(len(data)))


### PR DESCRIPTION
First, it supports the calculation of the counter of `packet-loss-rate`. When the queries from `dashboard` include a counter of `packet-loss-rate`, response to `dashboard` with the the results based on the data other counters of `packets-sent` & `packets-received`. Second, it supports the calculation of the counter of `average`. Now the meaning of `average` is only for transmission time. When the queries include a counter of `average`, response to `dashboard` with the the results based on the data of other counters of `transmission time`.
